### PR TITLE
chore: add frontend deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
     branches: [main]
     paths:
       - "frontend/**"
-      - "backend/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Deploy
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - "backend/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Deploy
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          envs: GITHUB_SERVER_URL,GITHUB_REPOSITORY
+          script: npx nginx-proxy-cli deploy $GITHUB_SERVER_URL/$GITHUB_REPOSITORY --dir=~/nginx-proxy/applications

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        # TODO: set to actual backend url when its deployed
+        VITE_API_HOST: "http://localhost:3000"
+    restart: always
+    environment:
+      VIRTUAL_HOST: "${FRONTEND_DOMAIN?:}"
+      LETSENCRYPT_HOST: "${FRONTEND_DOMAIN}"
+    networks:
+      - default
+      - nginx-proxy
+
+networks:
+  default:
+  nginx-proxy:
+    external: true

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,6 +1,5 @@
 .github
 .git
-.husky
 .vscode
 dist
 node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,5 +19,5 @@ RUN pnpm build
 FROM nginx:stable-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
-EXPOSE 8080
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,9 @@ RUN npm i -g $(node -p "require('./package.json').packageManager")
 
 RUN pnpm install --frozen-lockfile
 
+ARG VITE_API_HOST
+ENV VITE_API_HOST $VITE_API_HOST
+
 COPY . ./
 RUN pnpm build
 

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "3"
-
-services:
-  app:
-    build: .
-    restart: unless-stopped
-    ports:
-      - "8080:8080"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "test:unit": "vitest --environment jsdom",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
-    "lint": "eslint . --ext .vue,.js,.ts --fix --ignore-path .gitignore",
+    "lint": "eslint . --ext .vue,.js,.ts --fix --ignore-path ../.gitignore",
     "storybook": "storybook dev -p 6006",
     "prepare": "simple-git-hooks",
     "preinstall": "npx only-allow pnpm"


### PR DESCRIPTION
All frontend updates on `main` branch will be deployed to `https://drink.lars-rickert.de` so we can quickly check them :)

I am not sure about the URL but we can easily change it in the future.